### PR TITLE
feat(participants): display names, add filters, and bulk edit voting rights

### DIFF
--- a/src/components/ManageParticipants.tsx
+++ b/src/components/ManageParticipants.tsx
@@ -195,7 +195,7 @@ export default function ManageParticipants({
               ...(data?.participants ?? []).map((p) => ({
                   id: p.id,
                   email: p.user.email,
-                  name: p.user.name as string | undefined,
+                  name: p.user.name,
                   role: p.role,
                   isVotingEligible: p.isVotingEligible,
                   isParticipant: true,

--- a/src/components/ManageParticipants.tsx
+++ b/src/components/ManageParticipants.tsx
@@ -165,6 +165,7 @@ export default function ManageParticipants({
         ? (localParticipants ?? []).map((p, i) => ({
               id: String(i),
               email: p.email,
+              name: undefined as string | undefined,
               role: p.role,
               isVotingEligible: p.isVotingEligible,
               isParticipant: false,
@@ -174,15 +175,16 @@ export default function ManageParticipants({
               ...(data?.participants ?? []).map((p) => ({
                   id: p.id,
                   email: p.user.email,
+                  name: p.user.name as string | undefined,
                   role: p.role,
                   isVotingEligible: p.isVotingEligible,
                   isParticipant: true,
-                  name: p.user.name,
                   isOwner: p.userId === data?.ownerId,
               })),
               ...(data?.invites ?? []).map((inv) => ({
                   id: `invite-${inv.email}`,
                   email: inv.email,
+                  name: undefined as string | undefined,
                   role: inv.role,
                   isVotingEligible: inv.isVotingEligible,
                   isParticipant: false,
@@ -191,9 +193,13 @@ export default function ManageParticipants({
           ];
 
     const filtered = search
-        ? displayParticipants.filter((p) =>
-              p.email.toLowerCase().includes(search.toLowerCase()),
-          )
+        ? displayParticipants.filter((p) => {
+              const term = search.toLowerCase();
+              const name = p.name ? p.name.toLowerCase() : '';
+              return (
+                  name.includes(term) || p.email.toLowerCase().includes(term)
+              );
+          })
         : displayParticipants;
 
     return (
@@ -304,6 +310,9 @@ export default function ManageParticipants({
                             )}
                             <div className="flex-1">
                                 <p className="text-sm font-medium text-foreground">
+                                    {p.name ?? p.email}
+                                </p>
+                                <p className="text-xs text-muted-foreground">
                                     {p.email}
                                 </p>
                                 {!p.isParticipant && (

--- a/src/components/ManageParticipants.tsx
+++ b/src/components/ManageParticipants.tsx
@@ -5,6 +5,7 @@ import {
     addParticipants,
     updateParticipant,
     deleteParticipants,
+    bulkUpdateVotingEligibility,
 } from '#/server/participants.ts';
 import { Button } from '#/components/ui/button';
 import { Input } from '#/components/ui/input';
@@ -48,6 +49,9 @@ export default function ManageParticipants({
         'PARTICIPANT',
     );
     const [search, setSearch] = useState('');
+    const [filter, setFilter] = useState<'all' | 'eligible' | 'not_eligible'>(
+        'all',
+    );
     const [selected, setSelected] = useState<Set<string>>(new Set());
     const [csvText, setCsvText] = useState('');
     const [csvErrors, setCsvErrors] = useState<string[]>([]);
@@ -94,6 +98,22 @@ export default function ManageParticipants({
                     meetingId: meetingId!,
                     participantIds: Array.from(selected),
                 },
+            }),
+        onSuccess: () => {
+            setSelected(new Set());
+            void queryClient.invalidateQueries({
+                queryKey: ['participants', meetingId],
+            });
+        },
+    });
+
+    const bulkVotingMutation = useMutation({
+        mutationFn: (params: {
+            participantIds: string[];
+            isVotingEligible: boolean;
+        }) =>
+            bulkUpdateVotingEligibility({
+                data: { meetingId: meetingId!, ...params },
             }),
         onSuccess: () => {
             setSelected(new Set());
@@ -192,15 +212,16 @@ export default function ManageParticipants({
               })),
           ];
 
-    const filtered = search
-        ? displayParticipants.filter((p) => {
-              const term = search.toLowerCase();
-              const name = p.name ? p.name.toLowerCase() : '';
-              return (
-                  name.includes(term) || p.email.toLowerCase().includes(term)
-              );
-          })
-        : displayParticipants;
+    const filtered = displayParticipants.filter((p) => {
+        if (filter === 'eligible' && !p.isVotingEligible) return false;
+        if (filter === 'not_eligible' && p.isVotingEligible) return false;
+        if (search) {
+            const term = search.toLowerCase();
+            const name = p.name ? p.name.toLowerCase() : '';
+            return name.includes(term) || p.email.toLowerCase().includes(term);
+        }
+        return true;
+    });
 
     return (
         <div className="space-y-6">
@@ -270,24 +291,100 @@ export default function ManageParticipants({
             </div>
 
             <div>
-                <div className="mb-3 flex items-center gap-3">
-                    <h3 className="text-lg font-semibold text-foreground">
-                        Deltakere ({displayParticipants.length})
-                    </h3>
-                    <Input
-                        placeholder="Sok..."
-                        value={search}
-                        onChange={(e) => setSearch(e.target.value)}
-                        className="max-w-xs"
-                    />
-                    {selected.size > 0 && !isLocal && (
-                        <Button
-                            variant="destructive"
-                            size="sm"
-                            onClick={() => deleteMutation.mutate()}
-                        >
-                            Slett valgte ({selected.size})
-                        </Button>
+                <div className="mb-3 space-y-2">
+                    <div className="flex items-center gap-3">
+                        <h3 className="text-lg font-semibold text-foreground">
+                            Deltakere ({displayParticipants.length})
+                        </h3>
+                        <Input
+                            placeholder="Sok..."
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                            className="max-w-xs"
+                        />
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <span className="text-xs text-muted-foreground">
+                            Filter:
+                        </span>
+                        {(
+                            [
+                                ['all', 'Alle'],
+                                ['eligible', 'Stemmerett'],
+                                ['not_eligible', 'Uten stemmerett'],
+                            ] as const
+                        ).map(([value, label]) => (
+                            <Button
+                                key={value}
+                                type="button"
+                                size="sm"
+                                variant={
+                                    filter === value ? 'default' : 'outline'
+                                }
+                                onClick={() => setFilter(value)}
+                            >
+                                {label}
+                            </Button>
+                        ))}
+                    </div>
+                    {!isLocal && (
+                        <div className="flex items-center gap-2">
+                            <Checkbox
+                                checked={
+                                    filtered.length > 0 &&
+                                    filtered.every((p) => selected.has(p.id))
+                                }
+                                onCheckedChange={(checked) => {
+                                    if (checked) {
+                                        setSelected(
+                                            new Set(filtered.map((p) => p.id)),
+                                        );
+                                    } else {
+                                        setSelected(new Set());
+                                    }
+                                }}
+                            />
+                            <span className="text-xs text-muted-foreground">
+                                Velg alle ({filtered.length})
+                            </span>
+                            {selected.size > 0 && (
+                                <>
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() =>
+                                            bulkVotingMutation.mutate({
+                                                participantIds:
+                                                    Array.from(selected),
+                                                isVotingEligible: true,
+                                            })
+                                        }
+                                    >
+                                        Gi stemmerett ({selected.size})
+                                    </Button>
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() =>
+                                            bulkVotingMutation.mutate({
+                                                participantIds:
+                                                    Array.from(selected),
+                                                isVotingEligible: false,
+                                            })
+                                        }
+                                    >
+                                        Fjern stemmerett ({selected.size})
+                                    </Button>
+                                    <Button
+                                        variant="destructive"
+                                        size="sm"
+                                        onClick={() => deleteMutation.mutate()}
+                                    >
+                                        Slett valgte ({selected.size})
+                                    </Button>
+                                </>
+                            )}
+                        </div>
                     )}
                 </div>
 

--- a/src/server/participants.ts
+++ b/src/server/participants.ts
@@ -190,6 +190,27 @@ export const updateParticipant = createServerFn({ method: 'POST' })
         return updated;
     });
 
+const bulkUpdateVotingEligibilitySchema = z.object({
+    meetingId: z.string(),
+    participantIds: z.array(z.string()),
+    isVotingEligible: z.boolean(),
+});
+
+export const bulkUpdateVotingEligibility = createServerFn({ method: 'POST' })
+    .inputValidator(bulkUpdateVotingEligibilitySchema)
+    .handler(async ({ data }) => {
+        await requireAdmin(data.meetingId);
+
+        for (const pid of data.participantIds) {
+            await db
+                .update(participant)
+                .set({ isVotingEligible: data.isVotingEligible })
+                .where(eq(participant.id, pid));
+        }
+
+        return { updatedCount: data.participantIds.length };
+    });
+
 export const deleteParticipants = createServerFn({ method: 'POST' })
     .inputValidator(
         z.object({


### PR DESCRIPTION
## Summary
- Display participant names as the primary identifier instead of email addresses, with email shown as secondary text (#8)
- Add filter buttons to view participants by voting eligibility: all, with voting rights, without voting rights (#9)
- Add select all checkbox and bulk actions to grant or remove voting rights for multiple selected participants (#10)
- New `bulkUpdateVotingEligibility` server endpoint for efficient bulk updates

Closes #8
Closes #9
Closes #10

## Test plan
- [ ] Verify participant names are displayed as primary text, email as secondary
- [ ] Verify invited users (no name) fall back to showing email
- [ ] Verify search works by both name and email
- [ ] Verify filter buttons correctly filter by voting eligibility
- [ ] Verify "select all" checkbox selects/deselects all visible participants
- [ ] Verify "Gi stemmerett" bulk action grants voting rights to all selected
- [ ] Verify "Fjern stemmerett" bulk action removes voting rights from all selected
- [ ] Verify bulk delete still works for selected participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)