### PR TITLE
feat(voting): show who hasn't voted and inline votation editing

### DIFF
--- a/src/components/ActiveVotation.tsx
+++ b/src/components/ActiveVotation.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useMemo } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { toast } from 'sonner';
 import { getVotationById } from '#/server/votations.ts';
 import {
@@ -9,6 +10,7 @@ import {
     getVoteCount,
     getHasVoted,
     updateVotationStatus,
+    getNotVotedParticipants,
 } from '#/server/voting.ts';
 import { Button } from '#/components/ui/button';
 import { useWsSubscription } from '#/hooks/useWsSubscription';
@@ -84,6 +86,7 @@ export default function ActiveVotation({
                     alternatives={votation.alternatives}
                     blankVotes={votation.blankVotes}
                     isAdmin={isAdmin}
+                    isAdminOrCounter={isAdminOrCounter}
                     canVote={canVote}
                 />
             )}
@@ -124,6 +127,7 @@ function VotingInterface({
     alternatives,
     blankVotes,
     isAdmin,
+    isAdminOrCounter,
     canVote,
 }: {
     votationId: string;
@@ -132,6 +136,7 @@ function VotingInterface({
     alternatives: Array<{ id: string; text: string }>;
     blankVotes: boolean;
     isAdmin: boolean;
+    isAdminOrCounter: boolean;
     canVote: boolean;
 }) {
     const [selectedAlt, setSelectedAlt] = useState<string | null>(null);
@@ -247,6 +252,7 @@ function VotingInterface({
                     </p>
                 </div>
                 <VoteCountDisplay voteCount={voteCount} />
+                {isAdminOrCounter && <NotVotedList votationId={votationId} />}
                 {isAdmin && (
                     <AdminVotingControls
                         onClose={() => closeMutation.mutate()}
@@ -268,6 +274,7 @@ function VotingInterface({
                     </p>
                 </div>
                 <VoteCountDisplay voteCount={voteCount} />
+                {isAdminOrCounter && <NotVotedList votationId={votationId} />}
                 {isAdmin && (
                     <AdminVotingControls
                         onClose={() => closeMutation.mutate()}
@@ -383,6 +390,7 @@ function VotingInterface({
                 </div>
 
                 <VoteCountDisplay voteCount={voteCount} />
+                {isAdminOrCounter && <NotVotedList votationId={votationId} />}
                 {isAdmin && (
                     <AdminVotingControls
                         onClose={() => closeMutation.mutate()}
@@ -435,6 +443,7 @@ function VotingInterface({
             </div>
 
             <VoteCountDisplay voteCount={voteCount} />
+            {isAdminOrCounter && <NotVotedList votationId={votationId} />}
             {isAdmin && (
                 <AdminVotingControls
                     onClose={() => closeMutation.mutate()}
@@ -496,6 +505,52 @@ function AdminVotingControls({
             >
                 {invalidating ? 'Avbryter...' : 'Avbryt votering'}
             </Button>
+        </div>
+    );
+}
+
+function NotVotedList({ votationId }: { votationId: string }) {
+    const [open, setOpen] = useState(false);
+
+    const { data: notVoted } = useQuery({
+        queryKey: ['notVoted', votationId],
+        queryFn: () => getNotVotedParticipants({ data: { votationId } }),
+        refetchInterval: 10000,
+    });
+
+    useWsSubscription(`votation:${votationId}:votes`, {
+        invalidate: [['notVoted', votationId]],
+    });
+
+    if (!notVoted || notVoted.length === 0) return null;
+
+    return (
+        <div className="rounded-lg border bg-muted/30 p-4">
+            <button
+                type="button"
+                className="flex w-full items-center gap-2 text-sm font-semibold text-foreground"
+                onClick={() => setOpen(!open)}
+            >
+                <ChevronDown
+                    className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`}
+                />
+                Har ikke stemt enn\u00e5 ({notVoted.length})
+            </button>
+            {open && (
+                <div className="mt-2 space-y-1">
+                    {notVoted.map((p) => (
+                        <div
+                            key={p.id}
+                            className="flex items-center justify-between rounded border bg-background px-3 py-2 text-sm"
+                        >
+                            <span>{p.name}</span>
+                            <span className="text-muted-foreground">
+                                {p.email}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/VotationList.tsx
+++ b/src/components/VotationList.tsx
@@ -1,10 +1,21 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Pencil, X, Check } from 'lucide-react';
 import { Badge } from '#/components/ui/badge';
+import { Button } from '#/components/ui/button';
+import { updateVotations } from '#/server/votations.ts';
 
 interface VotationItem {
     id: string;
     title: string;
+    description?: string | null;
     status: string;
     type: string;
+    blankVotes: boolean;
+    hiddenVotes: boolean;
+    numberOfWinners: number;
+    majorityThreshold: number;
     index: number;
     alternatives: Array<{ id: string; text: string; isWinner: boolean }>;
 }
@@ -35,6 +46,8 @@ const statusColors: Record<string, string> = {
 
 export default function VotationList({
     votations,
+    meetingId,
+    isAdmin,
     onViewActive,
 }: VotationListProps) {
     const active = votations.filter((v) => v.status === 'OPEN');
@@ -78,14 +91,13 @@ export default function VotationList({
                     <h2 className="mb-3 text-lg font-semibold text-foreground">
                         Neste votering
                     </h2>
-                    <div className="rounded-xl border bg-card p-4">
-                        <div className="flex items-center gap-2">
-                            <Badge variant="secondary">Neste</Badge>
-                            <span className="font-medium text-foreground">
-                                {nextVotation.title}
-                            </span>
-                        </div>
-                    </div>
+                    <VotationCard
+                        votation={nextVotation}
+                        meetingId={meetingId}
+                        isAdmin={isAdmin}
+                        badgeVariant="secondary"
+                        badgeLabel="Neste"
+                    />
                 </section>
             )}
 
@@ -96,27 +108,20 @@ export default function VotationList({
                     </h2>
                     <div className="space-y-2">
                         {upcoming.slice(1).map((v) => (
-                            <div
+                            <VotationCard
                                 key={v.id}
-                                className="rounded-lg border bg-card p-3"
-                            >
-                                <div className="flex items-center gap-2">
-                                    <Badge
-                                        variant={
-                                            statusColors[v.status] as
-                                                | 'default'
-                                                | 'secondary'
-                                                | 'outline'
-                                                | 'destructive'
-                                        }
-                                    >
-                                        {statusLabels[v.status]}
-                                    </Badge>
-                                    <span className="text-sm text-foreground">
-                                        {v.title}
-                                    </span>
-                                </div>
-                            </div>
+                                votation={v}
+                                meetingId={meetingId}
+                                isAdmin={isAdmin}
+                                badgeVariant={
+                                    statusColors[v.status] as
+                                        | 'default'
+                                        | 'secondary'
+                                        | 'outline'
+                                        | 'destructive'
+                                }
+                                badgeLabel={statusLabels[v.status]}
+                            />
                         ))}
                     </div>
                 </section>
@@ -173,6 +178,193 @@ export default function VotationList({
                     Ingen voteringer er opprettet for dette møtet enna.
                 </p>
             )}
+        </div>
+    );
+}
+
+function VotationCard({
+    votation,
+    meetingId,
+    isAdmin,
+    badgeVariant,
+    badgeLabel,
+}: {
+    votation: VotationItem;
+    meetingId: string;
+    isAdmin: boolean;
+    badgeVariant: 'default' | 'secondary' | 'outline' | 'destructive';
+    badgeLabel: string;
+}) {
+    const [editing, setEditing] = useState(false);
+    const [title, setTitle] = useState(votation.title);
+    const [description, setDescription] = useState(votation.description ?? '');
+    const [alternatives, setAlternatives] = useState(
+        votation.alternatives.map((a) => ({ id: a.id, text: a.text })),
+    );
+    const queryClient = useQueryClient();
+
+    const editMutation = useMutation({
+        mutationFn: () =>
+            updateVotations({
+                data: {
+                    meetingId,
+                    votations: [
+                        {
+                            id: votation.id,
+                            title,
+                            description: description || undefined,
+                            type: votation.type as
+                                | 'SIMPLE'
+                                | 'QUALIFIED'
+                                | 'STV',
+                            blankVotes: votation.blankVotes,
+                            hiddenVotes: votation.hiddenVotes,
+                            numberOfWinners: votation.numberOfWinners,
+                            majorityThreshold: votation.majorityThreshold,
+                            index: votation.index,
+                            alternatives: alternatives.map((a, i) => ({
+                                id: a.id,
+                                text: a.text,
+                                index: i,
+                            })),
+                        },
+                    ],
+                },
+            }),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({
+                queryKey: ['votations', meetingId],
+            });
+            setEditing(false);
+            toast.success('Votering oppdatert');
+        },
+        onError: (err) => {
+            toast.error(
+                err instanceof Error
+                    ? err.message
+                    : 'Kunne ikke oppdatere votering',
+            );
+        },
+    });
+
+    const canEdit = isAdmin && votation.status === 'UPCOMING';
+
+    if (editing) {
+        return (
+            <div className="space-y-3 rounded-xl border bg-card p-4">
+                <div className="flex items-center justify-between">
+                    <Badge variant={badgeVariant}>{badgeLabel}</Badge>
+                    <div className="flex gap-1">
+                        <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => editMutation.mutate()}
+                            disabled={editMutation.isPending}
+                        >
+                            <Check className="h-4 w-4" />
+                        </Button>
+                        <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => {
+                                setTitle(votation.title);
+                                setDescription(votation.description ?? '');
+                                setAlternatives(
+                                    votation.alternatives.map((a) => ({
+                                        id: a.id,
+                                        text: a.text,
+                                    })),
+                                );
+                                setEditing(false);
+                            }}
+                        >
+                            <X className="h-4 w-4" />
+                        </Button>
+                    </div>
+                </div>
+                <input
+                    type="text"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    className="w-full rounded-md border bg-background px-3 py-2 text-sm font-medium"
+                    placeholder="Tittel"
+                />
+                <input
+                    type="text"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                    placeholder="Beskrivelse (valgfritt)"
+                />
+                <div className="space-y-1">
+                    <p className="text-xs font-medium text-muted-foreground">
+                        Alternativer
+                    </p>
+                    {alternatives.map((alt, i) => (
+                        <div key={alt.id} className="flex items-center gap-2">
+                            <input
+                                type="text"
+                                value={alt.text}
+                                onChange={(e) => {
+                                    const updated = [...alternatives];
+                                    updated[i] = {
+                                        ...updated[i],
+                                        text: e.target.value,
+                                    };
+                                    setAlternatives(updated);
+                                }}
+                                className="flex-1 rounded-md border bg-background px-3 py-1.5 text-sm"
+                            />
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    setAlternatives(
+                                        alternatives.filter(
+                                            (_, idx) => idx !== i,
+                                        ),
+                                    )
+                                }
+                                className="text-xs text-destructive hover:underline"
+                            >
+                                Fjern
+                            </button>
+                        </div>
+                    ))}
+                    <button
+                        type="button"
+                        onClick={() =>
+                            setAlternatives([
+                                ...alternatives,
+                                { id: '', text: '' },
+                            ])
+                        }
+                        className="text-xs text-primary hover:underline"
+                    >
+                        + Legg til alternativ
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="rounded-xl border bg-card p-4">
+            <div className="flex items-center gap-2">
+                <Badge variant={badgeVariant}>{badgeLabel}</Badge>
+                <span className="font-medium text-foreground">
+                    {votation.title}
+                </span>
+                {canEdit && (
+                    <button
+                        type="button"
+                        onClick={() => setEditing(true)}
+                        className="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                        title="Rediger votering"
+                    >
+                        <Pencil className="h-4 w-4" />
+                    </button>
+                )}
+            </div>
         </div>
     );
 }

--- a/src/server/voting.ts
+++ b/src/server/voting.ts
@@ -520,6 +520,49 @@ export const getMyReview = createServerFn({ method: 'GET' })
         return review ?? null;
     });
 
+export const getNotVotedParticipants = createServerFn({ method: 'GET' })
+    .inputValidator(z.object({ votationId: z.string() }))
+    .handler(async ({ data }) => {
+        const v = await db.query.votation.findFirst({
+            where: eq(votation.id, data.votationId),
+        });
+        if (!v) throw new Error('Voteringen finnes ikke');
+
+        await requireAdminOrCounter(v.meetingId);
+
+        // Get all voting-eligible participants
+        const eligibleParticipants = await db.query.participant.findMany({
+            where: and(
+                eq(participant.meetingId, v.meetingId),
+                eq(participant.isVotingEligible, true),
+                eq(participant.isApproved, true),
+            ),
+            with: { user: true },
+        });
+
+        // Filter out admins (they can't vote)
+        const nonAdminEligible = eligibleParticipants.filter(
+            (p) => p.role !== 'ADMIN',
+        );
+
+        // Get who has voted
+        const voters = await db.query.hasVoted.findMany({
+            where: eq(hasVoted.votationId, data.votationId),
+        });
+        const votedUserIds = new Set(voters.map((v) => v.userId));
+
+        // Return those who haven't voted
+        const notVoted = nonAdminEligible.filter(
+            (p) => !votedUserIds.has(p.userId),
+        );
+
+        return notVoted.map((p) => ({
+            id: p.id,
+            name: p.user.name,
+            email: p.user.email,
+        }));
+    });
+
 export const getReviewerCount = createServerFn({ method: 'GET' })
     .inputValidator(z.object({ meetingId: z.string() }))
     .handler(async ({ data }) => {


### PR DESCRIPTION
## Summary
- **Issue #7**: Admins and counters can now see a collapsible list of participants who haven't voted yet during an active votation, with real-time updates via WebSocket
- **Issue #11**: Admins can now directly edit upcoming votations (title, description, alternatives) inline from the votation list view without navigating to the full setup wizard
- Added `getNotVotedParticipants` server function with proper admin/counter permission checks

## Test plan
- [ ] Open an active votation as admin/counter and verify the "Har ikke stemt ennå" collapsible section appears below the vote count
- [ ] Verify the list updates in real-time as participants cast votes
- [ ] Verify the list is not visible to regular participants
- [ ] Click the pencil icon on an upcoming votation in the list view
- [ ] Edit title, description, and alternatives inline and save
- [ ] Verify changes persist after page refresh
- [ ] Verify the edit button does not appear on non-UPCOMING votations
- [ ] Verify only admins see the edit button

Closes #7, Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)